### PR TITLE
fix: give write permissions for gh action to create release

### DIFF
--- a/.github/workflows/publish-node-sdk.yml
+++ b/.github/workflows/publish-node-sdk.yml
@@ -6,8 +6,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### Description
- Remove read only access for github action to publish package

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
