### PR TITLE
fix: added bundler script for types + exported OAuthClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makeplane/plane-node-sdk",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Node SDK for Plane",
   "author": "Plane <engineering@plane.so>",
   "repository": {
@@ -14,7 +14,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build:types-bundle": "dts-bundle-generator --no-check -o dist/types.bundle.d.ts dist/index.d.ts",
+    "build": "tsc && pnpm run build:types-bundle",
     "dev": "tsc --watch",
     "test": "jest",
     "test:unit": "jest --testPathPattern=tests/unit",
@@ -46,6 +47,7 @@
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",
+    "dts-bundle-generator": "^9.5.1",
     "eslint": "9.38.0",
     "eslint-plugin-unused-imports": "^4.3.0",
     "globals": "^16.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.46.2
         version: 8.46.2(eslint@9.38.0)(typescript@5.9.3)
+      dts-bundle-generator:
+        specifier: ^9.5.1
+        version: 9.5.1
       eslint:
         specifier: 9.38.0
         version: 9.38.0
@@ -732,6 +735,11 @@ packages:
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+
+  dts-bundle-generator@9.5.1:
+    resolution: {integrity: sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2558,6 +2566,11 @@ snapshots:
   diff-sequences@29.6.3: {}
 
   diff@4.0.2: {}
+
+  dts-bundle-generator@9.5.1:
+    dependencies:
+      typescript: 5.9.3
+      yargs: 17.7.2
 
   dunder-proto@1.0.1:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 // Main client
 export { PlaneClient } from "./client/plane-client";
 
+// OAuth client
+export { OAuthClient } from "./client/oauth-client";
+
 // Configuration
 export { Configuration } from "./Configuration";
 


### PR DESCRIPTION
### Description
- added bundler script for types 
- exported OAuthClient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuthClient is now publicly exported and available for import.

* **Chores**
  * Bumped version to 0.2.6.
  * Improved build process to automatically bundle TypeScript declarations.
  * Added development tooling dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->