### PR TITLE
chore: switch npm publish to trusted publishers via OIDC

### DIFF
--- a/.github/workflows/publish-node-sdk.yml
+++ b/.github/workflows/publish-node-sdk.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
-          node-version: '20'
+          node-version: '22'
 
       - name: Enable corepack
         run: corepack enable pnpm
@@ -31,7 +31,7 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: pnpm publish --access public --provenance
+        run: npm publish --access public
 
       - name: Get version from package.json
         id: package-version

--- a/.github/workflows/publish-node-sdk.yml
+++ b/.github/workflows/publish-node-sdk.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          node-version: '22'
 
       - name: Enable corepack
         run: corepack enable pnpm


### PR DESCRIPTION
### Description
- Update the publish workflow to use npm trusted publishers instead of NPM_TOKEN secret for authentication. 
- Uses OIDC-based auth as recommended by npm docs — bumps to actions/checkout@v6, actions/setup-node@v6, Node 24, adds id-token: write permission, and removes the NPM_TOKEN dependency.

### Type of Change
- [X] Feature (non-breaking change which adds functionality)

### Screenshots and Media (if applicable)
<img width="1584" height="428" alt="CleanShot 2026-03-28 at 01 26 03@2x" src="https://github.com/user-attachments/assets/675a4d9e-fb56-4436-8f92-e2968149c4a9" />

### Test Scenarios 
Published using github action from the branch:
https://github.com/makeplane/plane-node-sdk/actions/runs/23664758333/job/68943804887



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure dependencies and build tooling configurations to improve build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->