### PR TITLE
[WEB-6816] chore: added support for pql filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makeplane/plane-node-sdk",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Node SDK for Plane",
   "author": "Plane <engineering@plane.so>",
   "repository": {

--- a/src/models/WorkItem.ts
+++ b/src/models/WorkItem.ts
@@ -48,8 +48,8 @@ export type WorkItemExpandableFieldName = keyof WorkItemExpandableFields;
 export type WorkItem<Expanded extends WorkItemExpandableFieldName = never> = [Expanded] extends [never]
   ? WorkItemBase
   : Omit<WorkItemBase, Expanded> & {
-    [K in Expanded]: K extends keyof WorkItemExpandableFields ? WorkItemExpandableFields[K] : never;
-  };
+      [K in Expanded]: K extends keyof WorkItemExpandableFields ? WorkItemExpandableFields[K] : never;
+    };
 
 export interface CreateWorkItem {
   name: string;

--- a/src/models/WorkItem.ts
+++ b/src/models/WorkItem.ts
@@ -48,8 +48,8 @@ export type WorkItemExpandableFieldName = keyof WorkItemExpandableFields;
 export type WorkItem<Expanded extends WorkItemExpandableFieldName = never> = [Expanded] extends [never]
   ? WorkItemBase
   : Omit<WorkItemBase, Expanded> & {
-      [K in Expanded]: K extends keyof WorkItemExpandableFields ? WorkItemExpandableFields[K] : never;
-    };
+    [K in Expanded]: K extends keyof WorkItemExpandableFields ? WorkItemExpandableFields[K] : never;
+  };
 
 export interface CreateWorkItem {
   name: string;
@@ -87,6 +87,7 @@ export interface ListWorkItemsParams {
   assignee?: string;
   limit?: number;
   offset?: number;
+  pql?: string;
 }
 
 export interface WorkItemActivity {

--- a/tests/unit/work-items/work-items.test.ts
+++ b/tests/unit/work-items/work-items.test.ts
@@ -83,18 +83,25 @@ describe(!!(config.workspaceSlug && config.projectId && config.userId), "Work It
   });
 
   it("should list work items with pql filter", async () => {
-    const allWorkItems = await client.workItems.list(workspaceSlug, projectId);
-    const priority = allWorkItems.results[0]?.priority ?? "none";
+    const name = randomizeName();
+    const pqlWorkItem = await client.workItems.create(workspaceSlug, projectId, {
+      name,
+      priority: "high",
+    });
 
     const filtered = await client.workItems.list(workspaceSlug, projectId, {
-      pql: `priority IN ("${priority}")`,
+      pql: 'priority IN ("high")',
     });
 
     expect(filtered).toBeDefined();
     expect(Array.isArray(filtered.results)).toBe(true);
+    expect(filtered.results.length).toBeGreaterThan(0);
+    expect(filtered.results.find((wi) => wi.id === pqlWorkItem.id)).toBeDefined();
     for (const wi of filtered.results) {
-      expect(wi.priority).toBe(priority);
+      expect(wi.priority).toBe("high");
     }
+
+    await client.workItems.delete(workspaceSlug, projectId, pqlWorkItem.id!);
   });
 
   it("should retrieve work item by identifier", async () => {

--- a/tests/unit/work-items/work-items.test.ts
+++ b/tests/unit/work-items/work-items.test.ts
@@ -99,7 +99,7 @@ describe(!!(config.workspaceSlug && config.projectId && config.userId), "Work It
       expect(filtered).toBeDefined();
       expect(Array.isArray(filtered.results)).toBe(true);
       expect(filtered.results.length).toBeGreaterThan(0);
-      expect(filtered.results.find((wi) => wi.id === pqlWorkItem.id)).toBeDefined();
+      expect(filtered.results.find((wi) => wi.id === pqlWorkItem!.id)).toBeDefined();
       for (const wi of filtered.results) {
         expect(wi.priority).toBe("high");
       }

--- a/tests/unit/work-items/work-items.test.ts
+++ b/tests/unit/work-items/work-items.test.ts
@@ -82,6 +82,21 @@ describe(!!(config.workspaceSlug && config.projectId && config.userId), "Work It
     expect(foundWorkItem).toBeDefined();
   });
 
+  it("should list work items with pql filter", async () => {
+    const allWorkItems = await client.workItems.list(workspaceSlug, projectId);
+    const priority = allWorkItems.results[0]?.priority ?? "none";
+
+    const filtered = await client.workItems.list(workspaceSlug, projectId, {
+      pql: `priority IN ("${priority}")`,
+    });
+
+    expect(filtered).toBeDefined();
+    expect(Array.isArray(filtered.results)).toBe(true);
+    for (const wi of filtered.results) {
+      expect(wi.priority).toBe(priority);
+    }
+  });
+
   it("should retrieve work item by identifier", async () => {
     const project = await client.projects.retrieve(workspaceSlug, projectId);
     const workItemByIdentifier = await client.workItems.retrieveByIdentifier(

--- a/tests/unit/work-items/work-items.test.ts
+++ b/tests/unit/work-items/work-items.test.ts
@@ -84,24 +84,34 @@ describe(!!(config.workspaceSlug && config.projectId && config.userId), "Work It
 
   it("should list work items with pql filter", async () => {
     const name = randomizeName();
-    const pqlWorkItem = await client.workItems.create(workspaceSlug, projectId, {
-      name,
-      priority: "high",
-    });
+    let pqlWorkItem: WorkItem | undefined;
 
-    const filtered = await client.workItems.list(workspaceSlug, projectId, {
-      pql: 'priority IN ("high")',
-    });
+    try {
+      pqlWorkItem = await client.workItems.create(workspaceSlug, projectId, {
+        name,
+        priority: "high",
+      });
 
-    expect(filtered).toBeDefined();
-    expect(Array.isArray(filtered.results)).toBe(true);
-    expect(filtered.results.length).toBeGreaterThan(0);
-    expect(filtered.results.find((wi) => wi.id === pqlWorkItem.id)).toBeDefined();
-    for (const wi of filtered.results) {
-      expect(wi.priority).toBe("high");
+      const filtered = await client.workItems.list(workspaceSlug, projectId, {
+        pql: 'priority IN ("high")',
+      });
+
+      expect(filtered).toBeDefined();
+      expect(Array.isArray(filtered.results)).toBe(true);
+      expect(filtered.results.length).toBeGreaterThan(0);
+      expect(filtered.results.find((wi) => wi.id === pqlWorkItem.id)).toBeDefined();
+      for (const wi of filtered.results) {
+        expect(wi.priority).toBe("high");
+      }
+    } finally {
+      if (pqlWorkItem?.id) {
+        try {
+          await client.workItems.delete(workspaceSlug, projectId, pqlWorkItem.id);
+        } catch {
+          // Best-effort cleanup to avoid polluting subsequent test runs.
+        }
+      }
     }
-
-    await client.workItems.delete(workspaceSlug, projectId, pqlWorkItem.id!);
   });
 
   it("should retrieve work item by identifier", async () => {


### PR DESCRIPTION
This pull request adds support for filtering work items using PQL (Project Query Language) in the work items API. The main changes introduce a new `pql` parameter to the work item listing functionality and include a corresponding unit test to ensure the filter works as expected.

**API Enhancements:**

* Added an optional `pql` parameter to the `ListWorkItemsParams` interface in `src/models/WorkItem.ts`, enabling clients to filter work items using PQL queries.

**Testing Improvements:**

* Added a unit test in `work-items.test.ts` to verify that the `pql` filter returns only work items matching the specified criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional PQL query filter when listing work items for more granular results.

* **Tests**
  * Added a unit test confirming PQL-based listing returns only matching work items and that created items are cleaned up.

* **Chores**
  * Bumped package version to 0.2.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->