### PR TITLE
feat: add AgentRunActivityAction type and action field to activity in…

### DIFF
--- a/src/api/AgentRuns/index.ts
+++ b/src/api/AgentRuns/index.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from "../BaseResource";
 import { Configuration } from "../../Configuration";
-import { AgentRun, CreateAgentRunRequest } from "../../models/AgentRun";
+import { AgentRun, CreateAgentRunRequest, UpdateAgentRunRequest } from "../../models/AgentRun";
 import { Activities } from "./Activities";
 
 /**
@@ -33,6 +33,17 @@ export class AgentRuns extends BaseResource {
    */
   async retrieve(workspaceSlug: string, runId: string): Promise<AgentRun> {
     return this.get<AgentRun>(`/workspaces/${workspaceSlug}/runs/${runId}/`);
+  }
+
+  /**
+   * Update an agent run
+   * @param workspaceSlug - The workspace slug
+   * @param runId - The agent run ID
+   * @param data - The fields to update
+   * @returns The updated agent run
+   */
+  async update(workspaceSlug: string, runId: string, data: UpdateAgentRunRequest): Promise<AgentRun> {
+    return this.patch<AgentRun>(`/workspaces/${workspaceSlug}/runs/${runId}/`, data);
   }
 }
 

--- a/src/models/AgentRun.ts
+++ b/src/models/AgentRun.ts
@@ -85,6 +85,14 @@ export interface AgentRunActivityTextContent {
 export type AgentRunActivityContent = AgentRunActivityActionContent | AgentRunActivityTextContent;
 
 /**
+ * Top-level action attached to an activity (e.g. a CTA button shown below the response body).
+ */
+export interface AgentRunActivityAction {
+  name: string;
+  redirect_url: string | null;
+}
+
+/**
  * Agent Run Activity interface
  */
 export interface AgentRunActivity extends BaseModel {
@@ -99,6 +107,7 @@ export interface AgentRunActivity extends BaseModel {
   type: AgentRunActivityType;
   project?: string;
   workspace: string;
+  actions?: AgentRunActivityAction[];
 }
 
 /**
@@ -111,4 +120,5 @@ export interface CreateAgentRunActivityRequest {
   signal_metadata?: Record<string, any>;
   type: Exclude<AgentRunActivityType, "prompt">;
   project?: string;
+  actions?: AgentRunActivityAction[];
 }

--- a/src/models/AgentRun.ts
+++ b/src/models/AgentRun.ts
@@ -63,6 +63,13 @@ export interface CreateAgentRunRequest {
 }
 
 /**
+ * Update agent run request interface
+ */
+export interface UpdateAgentRunRequest {
+  external_link?: string | null;
+}
+
+/**
  * Agent run activity content for action type
  */
 export interface AgentRunActivityActionContent {

--- a/src/models/AgentRun.ts
+++ b/src/models/AgentRun.ts
@@ -70,6 +70,14 @@ export interface UpdateAgentRunRequest {
 }
 
 /**
+ * Action button attached to an activity (e.g. a CTA shown below the response body).
+ */
+export interface AgentRunActivityAction {
+  name: string;
+  redirect_url: string | null;
+}
+
+/**
  * Agent run activity content for action type
  */
 export interface AgentRunActivityActionContent {
@@ -84,20 +92,13 @@ export interface AgentRunActivityActionContent {
 export interface AgentRunActivityTextContent {
   type: Exclude<AgentRunActivityType, "action">;
   body: string;
+  actions?: AgentRunActivityAction[];
 }
 
 /**
  * Agent run activity content
  */
 export type AgentRunActivityContent = AgentRunActivityActionContent | AgentRunActivityTextContent;
-
-/**
- * Top-level action attached to an activity (e.g. a CTA button shown below the response body).
- */
-export interface AgentRunActivityAction {
-  name: string;
-  redirect_url: string | null;
-}
 
 /**
  * Agent Run Activity interface
@@ -114,7 +115,6 @@ export interface AgentRunActivity extends BaseModel {
   type: AgentRunActivityType;
   project?: string;
   workspace: string;
-  actions?: AgentRunActivityAction[];
 }
 
 /**
@@ -127,5 +127,4 @@ export interface CreateAgentRunActivityRequest {
   signal_metadata?: Record<string, any>;
   type: Exclude<AgentRunActivityType, "prompt">;
   project?: string;
-  actions?: AgentRunActivityAction[];
 }


### PR DESCRIPTION
## Summary

- Adds `AgentRunActivityAction` interface with `name` and `redirect_url` fields
- Adds optional `action?: AgentRunActivityAction | null` to `AgentRunActivity` (response shape from API)
- Adds optional `action?: AgentRunActivityAction | null` to `CreateAgentRunActivityRequest` (request shape to API)

## Context

Agents need to attach a CTA button to response activities — for example, nudging a user to connect their account when a personal API key is missing. This button is a top-level `action` on the activity, separate from `content`, so the frontend can render it independently of the response body.

Without this type, passing `action` to `planeClient.agentRuns.activities.create(...)` is rejected as an unknown property.

## Changes

```ts
// New type
export interface AgentRunActivityAction {
  name: string;
  redirect_url: string | null;
}

// Added to AgentRunActivity
action?: AgentRunActivityAction | null;

// Added to CreateAgentRunActivityRequest
action?: AgentRunActivityAction | null;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activities on agent runs can include one or more actions with display names and optional redirect URLs, enabling users to trigger navigation or external flows directly from activity events.
  * Agent runs can be updated to include an optional external link, allowing runs to reference or redirect to related external resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->