### PR TITLE
[INFRA-401] feat(node-sdk): add importToProject, ProjectMember, WorkspaceMember — v0.2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makeplane/plane-node-sdk",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Node SDK for Plane",
   "author": "Plane <engineering@plane.so>",
   "repository": {

--- a/src/api/Projects.ts
+++ b/src/api/Projects.ts
@@ -2,7 +2,7 @@ import { BaseResource } from "./BaseResource";
 import { Configuration } from "../Configuration";
 import { Project, CreateProject, UpdateProject, ListProjectsParams } from "../models/Project";
 import { PaginatedResponse } from "../models/common";
-import { User } from "../models/User";
+import { ProjectMember } from "../models/Member";
 import { ProjectFeatures, UpdateProjectFeatures } from "../models/ProjectFeatures";
 
 /**
@@ -54,10 +54,10 @@ export class Projects extends BaseResource {
   }
 
   /**
-   * Get project members
+   * Get project members with their role information.
    */
-  async getMembers(workspaceSlug: string, projectId: string): Promise<User[]> {
-    return this.get<User[]>(`/workspaces/${workspaceSlug}/projects/${projectId}/members/`);
+  async getMembers(workspaceSlug: string, projectId: string): Promise<ProjectMember[]> {
+    return this.get<ProjectMember[]>(`/workspaces/${workspaceSlug}/projects/${projectId}/members/`);
   }
 
   /**

--- a/src/api/WorkItemTypes.ts
+++ b/src/api/WorkItemTypes.ts
@@ -68,4 +68,21 @@ export class WorkItemTypes extends BaseResource {
   async list(workspaceSlug: string, projectId: string, params?: ListWorkItemTypesParams): Promise<WorkItemType[]> {
     return this.get<WorkItemType[]>(`/workspaces/${workspaceSlug}/projects/${projectId}/work-item-types/`, params);
   }
+
+  /**
+   * Import workspace-level work item types into a project.
+   *
+   * @param workItemTypeIds - IDs of the workspace work item types to import.
+   * @returns The resulting project-level work item types after import.
+   */
+  async importToProject(
+    workspaceSlug: string,
+    projectId: string,
+    workItemTypeIds: string[]
+  ): Promise<WorkItemType[]> {
+    return this.post<WorkItemType[]>(
+      `/workspaces/${workspaceSlug}/projects/${projectId}/work-item-types/import-work-item-types/`,
+      { work_item_type_ids: workItemTypeIds }
+    );
+  }
 }

--- a/src/api/WorkItemTypes.ts
+++ b/src/api/WorkItemTypes.ts
@@ -75,11 +75,7 @@ export class WorkItemTypes extends BaseResource {
    * @param workItemTypeIds - IDs of the workspace work item types to import.
    * @returns The resulting project-level work item types after import.
    */
-  async importToProject(
-    workspaceSlug: string,
-    projectId: string,
-    workItemTypeIds: string[]
-  ): Promise<WorkItemType[]> {
+  async importToProject(workspaceSlug: string, projectId: string, workItemTypeIds: string[]): Promise<WorkItemType[]> {
     return this.post<WorkItemType[]>(
       `/workspaces/${workspaceSlug}/projects/${projectId}/work-item-types/import-work-item-types/`,
       { work_item_type_ids: workItemTypeIds }

--- a/src/api/Workspace.ts
+++ b/src/api/Workspace.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from "./BaseResource";
 import { Configuration } from "../Configuration";
-import { User } from "../models/User";
+import { WorkspaceMember } from "../models/Member";
 import { UpdateWorkspaceFeatures, WorkspaceFeatures } from "../models/WorkspaceFeatures";
 
 /**
@@ -13,10 +13,10 @@ export class Workspace extends BaseResource {
   }
 
   /**
-   * Get workspace members
+   * Get workspace members with their role information.
    */
-  async getMembers(workspaceSlug: string): Promise<User[]> {
-    return this.get<User[]>(`/workspaces/${workspaceSlug}/members/`);
+  async getMembers(workspaceSlug: string): Promise<WorkspaceMember[]> {
+    return this.get<WorkspaceMember[]>(`/workspaces/${workspaceSlug}/members/`);
   }
 
   /**

--- a/src/models/Member.ts
+++ b/src/models/Member.ts
@@ -1,0 +1,23 @@
+import { User } from "./User";
+
+/**
+ * A project member — a User with an additional role and role_slug field.
+ *
+ * Returned by Projects.getMembers(). The role field is the numeric role value
+ * (e.g. 20 = Member, 15 = Viewer, 10 = Guest, 5 = Viewer), role_slug is the
+ * human-readable equivalent (e.g. "member", "viewer").
+ */
+export interface ProjectMember extends User {
+  role: number | null;
+  role_slug: string | null;
+}
+
+/**
+ * A workspace member — a User with an additional role and role_slug field.
+ *
+ * Returned by Workspace.getMembers().
+ */
+export interface WorkspaceMember extends User {
+  role: number | null;
+  role_slug: string | null;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -10,6 +10,7 @@ export * from "./InitiativeLabel";
 export * from "./Intake";
 export * from "./Label";
 export * from "./Link";
+export * from "./Member";
 export * from "./Milestone";
 export * from "./Module";
 export * from "./OAuth";


### PR DESCRIPTION
## Summary

Mirrors the three additions from Python SDK v0.2.14 ([PR #43](https://github.com/makeplane/plane-python-sdk/pull/43)) into the Node SDK.

- **`WorkItemTypes.importToProject(workspaceSlug, projectId, workItemTypeIds)`** — `POST import-work-item-types/` — imports workspace-level work item types into a project
- **`ProjectMember`** interface — extends `User` with `role: number | null` and `role_slug: string | null`; `Projects.getMembers()` now returns `ProjectMember[]` instead of `User[]`
- **`WorkspaceMember`** interface — same role fields; `Workspace.getMembers()` now returns `WorkspaceMember[]` instead of `User[]`
- Both new types exported from `src/models/index.ts`
- Version bumped `0.2.11` → `0.2.12`

## Files changed

| File | Change |
|---|---|
| `src/models/Member.ts` | New — `ProjectMember` and `WorkspaceMember` interfaces |
| `src/models/index.ts` | Export `./Member` |
| `src/api/WorkItemTypes.ts` | Add `importToProject()` method |
| `src/api/Projects.ts` | `getMembers()` returns `ProjectMember[]` |
| `src/api/Workspace.ts` | `getMembers()` returns `WorkspaceMember[]` |
| `package.json` | Version `0.2.11` → `0.2.12` |

## Test plan

- [ ] `pnpm build` passes cleanly ✅
- [ ] `importToProject()` posts to correct endpoint with `{ work_item_type_ids: [...] }`
- [ ] `Projects.getMembers()` return type includes `role` and `role_slug`
- [ ] `Workspace.getMembers()` return type includes `role` and `role_slug`
- [ ] `ProjectMember` and `WorkspaceMember` exported from package root

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.2.12

* **New Features**
  * Added ability to import work item types from workspace level to projects.

* **Updates**
  * Member retrieval methods now return role information for workspace and project members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->