### PR TITLE
feat: add page update, archive, and delete APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makeplane/plane-node-sdk",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Node SDK for Plane",
   "author": "Plane <engineering@plane.so>",
   "repository": {

--- a/src/api/Pages.ts
+++ b/src/api/Pages.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from "./BaseResource";
 import { Configuration } from "../Configuration";
-import { Page, CreatePage } from "../models/Page";
+import { Page, CreatePage, UpdatePage } from "../models/Page";
 import { PaginatedResponse } from "../models/common";
 
 /**
@@ -35,6 +35,41 @@ export class Pages extends BaseResource {
     return this.get<PaginatedResponse<Page>>(`/workspaces/${workspaceSlug}/pages/`, params);
   }
 
+  /**
+   * Update a workspace page's name, content, or both. A page that is locked or
+   * archived is refused.
+   *
+   * Content is written through Plane's live collaboration service, which owns the
+   * document. If it is unreachable the API answers 502 and nothing is written,
+   * rather than leaving the editor showing the old text.
+   */
+  async updateWorkspacePage(workspaceSlug: string, pageId: string, updatePage: UpdatePage): Promise<Page> {
+    return this.put<Page>(`/workspaces/${workspaceSlug}/pages/${pageId}/`, updatePage);
+  }
+
+  /**
+   * Archive a workspace page. Archiving is the reversible step the API requires
+   * before a page can be deleted.
+   */
+  async archiveWorkspacePage(workspaceSlug: string, pageId: string): Promise<void> {
+    return this.post<void>(`/workspaces/${workspaceSlug}/pages/${pageId}/archive/`);
+  }
+
+  /**
+   * Restore an archived workspace page
+   */
+  async unarchiveWorkspacePage(workspaceSlug: string, pageId: string): Promise<void> {
+    return this.httpDelete(`/workspaces/${workspaceSlug}/pages/${pageId}/archive/`);
+  }
+
+  /**
+   * Delete a workspace page. The page must be archived first; the API answers 400
+   * "The page should be archived before deleting" otherwise.
+   */
+  async deleteWorkspacePage(workspaceSlug: string, pageId: string): Promise<void> {
+    return this.httpDelete(`/workspaces/${workspaceSlug}/pages/${pageId}/`);
+  }
+
   // ===== PROJECT PAGES API METHODS =====
 
   /**
@@ -56,6 +91,46 @@ export class Pages extends BaseResource {
    */
   async listProjectPages(workspaceSlug: string, projectId: string, params?: any): Promise<PaginatedResponse<Page>> {
     return this.get<PaginatedResponse<Page>>(`/workspaces/${workspaceSlug}/projects/${projectId}/pages/`, params);
+  }
+
+  /**
+   * Update a project page's name, content, or both. A page that is locked or
+   * archived is refused.
+   *
+   * Content is written through Plane's live collaboration service, which owns the
+   * document. If it is unreachable the API answers 502 and nothing is written,
+   * rather than leaving the editor showing the old text.
+   */
+  async updateProjectPage(
+    workspaceSlug: string,
+    projectId: string,
+    pageId: string,
+    updatePage: UpdatePage
+  ): Promise<Page> {
+    return this.put<Page>(`/workspaces/${workspaceSlug}/projects/${projectId}/pages/${pageId}/`, updatePage);
+  }
+
+  /**
+   * Archive a project page. Archiving is the reversible step the API requires
+   * before a page can be deleted.
+   */
+  async archiveProjectPage(workspaceSlug: string, projectId: string, pageId: string): Promise<void> {
+    return this.post<void>(`/workspaces/${workspaceSlug}/projects/${projectId}/pages/${pageId}/archive/`);
+  }
+
+  /**
+   * Restore an archived project page
+   */
+  async unarchiveProjectPage(workspaceSlug: string, projectId: string, pageId: string): Promise<void> {
+    return this.httpDelete(`/workspaces/${workspaceSlug}/projects/${projectId}/pages/${pageId}/archive/`);
+  }
+
+  /**
+   * Delete a project page. The page must be archived first; the API answers 400
+   * "The page should be archived before deleting" otherwise.
+   */
+  async deleteProjectPage(workspaceSlug: string, projectId: string, pageId: string): Promise<void> {
+    return this.httpDelete(`/workspaces/${workspaceSlug}/projects/${projectId}/pages/${pageId}/`);
   }
 
   /**

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -13,6 +13,19 @@ export interface Page extends BaseModel {
   description_stripped?: string;
   created_by: string;
   updated_by?: string;
+  /** 0 = public, 1 = private */
+  access?: number;
+  is_locked?: boolean;
+  /** Set when the page is archived; deleting a page requires it to be archived first */
+  archived_at?: string;
+  parent_id?: string;
+  /**
+   * Where the page is filed, and the id of the row that files it there -- the
+   * second is what addresses the membership when moving the page between
+   * collections. Both are null for a page in no collection.
+   */
+  collection_id?: string;
+  page_collection_id?: string;
   // Additional fields will be added after API verification
   [key: string]: any;
 }
@@ -23,3 +36,12 @@ export type CreatePage = Partial<Page> & {
   /** Create the page directly inside this collection */
   collection_id?: string;
 };
+
+/**
+ * Fields a page update may change. At least one is required; sending neither is
+ * refused with 400 "Either name or description_html is required."
+ */
+export interface UpdatePage {
+  name?: string;
+  description_html?: string;
+}

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -14,6 +14,7 @@ export interface Project extends BaseModel {
   cover_image_url: null;
   name: string;
   description: string;
+  description_html?: string;
   network?: number;
   identifier?: string;
   emoji?: null;

--- a/tests/unit/page.test.ts
+++ b/tests/unit/page.test.ts
@@ -72,4 +72,48 @@ describe(!!(config.workspaceSlug && config.projectId), "Page API Tests", () => {
     expect(Array.isArray(pages.results)).toBe(true);
     expect(pages.results.find((p) => p.id === projectPage.id)).toBeDefined();
   });
+
+  it("should update a workspace page", async () => {
+    const name = randomizeName("Updated Workspace Page");
+    const updated = await client.pages.updateWorkspacePage(workspaceSlug, workspacePage.id!, { name });
+
+    expect(updated.id).toBe(workspacePage.id);
+    expect(updated.name).toBe(name);
+  });
+
+  it("should update a project page's name and content", async () => {
+    const name = randomizeName("Updated Project Page");
+    const updated = await client.pages.updateProjectPage(workspaceSlug, projectId, projectPage.id!, {
+      name,
+      description_html: "<p>Revised Content</p>",
+    });
+
+    expect(updated.id).toBe(projectPage.id);
+    expect(updated.name).toBe(name);
+  });
+
+  it("should refuse an update that carries no field to change", async () => {
+    // Refused rather than reported as a successful no-op.
+    await expect(client.pages.updateProjectPage(workspaceSlug, projectId, projectPage.id!, {})).rejects.toThrow();
+  });
+
+  it("should archive and unarchive a workspace page", async () => {
+    await client.pages.archiveWorkspacePage(workspaceSlug, workspacePage.id!);
+    expect((await client.pages.retrieveWorkspacePage(workspaceSlug, workspacePage.id!)).archived_at).toBeTruthy();
+
+    await client.pages.unarchiveWorkspacePage(workspaceSlug, workspacePage.id!);
+    expect((await client.pages.retrieveWorkspacePage(workspaceSlug, workspacePage.id!)).archived_at).toBeFalsy();
+  });
+
+  it("should refuse to delete a page that is not archived", async () => {
+    const page = await client.pages.createProjectPage(workspaceSlug, projectId, {
+      name: randomizeName("Test Delete Page"),
+      description_html: "<p>Draft</p>",
+    });
+
+    await expect(client.pages.deleteProjectPage(workspaceSlug, projectId, page.id!)).rejects.toThrow();
+
+    await client.pages.archiveProjectPage(workspaceSlug, projectId, page.id!);
+    await client.pages.deleteProjectPage(workspaceSlug, projectId, page.id!);
+  });
 });


### PR DESCRIPTION
### Description

- Bumps SDK version to `0.2.13`
- Adds update, archive/unarchive, and delete support for workspace and project pages.

Eight methods on the `Pages` resource:

| | workspace | project |
|---|---|---|
| update | `updateWorkspacePage` | `updateProjectPage` |
| archive | `archiveWorkspacePage` | `archiveProjectPage` |
| unarchive | `unarchiveWorkspacePage` | `unarchiveProjectPage` |
| delete | `deleteWorkspacePage` | `deleteProjectPage` |

Delete had no method here at all, unlike the Python SDK — without it archive leads nowhere, so it's included.

`UpdatePage` carries `name` and `description_html` only. `PageUpdateAPISerializer` declares exactly those two and requires at least one, so anything else would be advertised but silently discarded server-side.

`Page` gains typed `access`, `is_locked`, `archived_at`, `parent_id`, `collection_id` and `page_collection_id`. They were already reachable through the interface's index signature; this makes them discoverable and documents `archived_at` as the delete precondition.

Two behaviours worth knowing at the call site, documented on the methods:
- Content is written through the live collaboration service, which owns the document. If it is unreachable the API answers 502 and nothing is written, rather than leaving the editor showing stale text.
- A page must be archived before it can be deleted; otherwise the API answers 400 "The page should be archived before deleting". Archiving stays reversible through the dedicated endpoints.

Locked or archived pages are refused for update.

### Type of Change
- [x] Feature (non-breaking change which adds functionality)

### Test Scenarios 
<img width="578" height="328" alt="Screenshot 2026-08-17 at 4 23 05 PM" src="https://github.com/user-attachments/assets/3d0fe18b-7bad-4e48-893c-e9cd3aace7c9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added support for updating, archiving, restoring, and deleting workspace and project pages.
- Added page metadata for access, locking, archival status, parent pages, and collections.
- Added support for updating page names and descriptions.
- Added support for displaying project descriptions.

## Bug Fixes

- Prevented empty page updates.
- Enforced archiving pages before deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->